### PR TITLE
chatgptのdom変化に対応

### DIFF
--- a/src/contents/chatgpt.ts
+++ b/src/contents/chatgpt.ts
@@ -9,12 +9,12 @@ export const config: PlasmoCSConfig = {
 
 const sendButton = {
   send: (elm: HTMLElement) => {
-    let sibling: HTMLElement | null = elm
-    while (sibling !== null) {
-      sibling = sibling.nextElementSibling as HTMLElement | null
-      if (sibling && sibling.getAttribute('data-testid') === 'send-button') {
-        return sibling as HTMLButtonElement
-      }
+    const parentElement = elm.parentElement
+    if (parentElement) {
+      const sendButton = parentElement.querySelector(
+        '[data-testid="send-button"]'
+      ) as HTMLButtonElement | null
+      return sendButton
     }
     return undefined
   },

--- a/src/contents/chatgpt.ts
+++ b/src/contents/chatgpt.ts
@@ -8,16 +8,10 @@ export const config: PlasmoCSConfig = {
 }
 
 const sendButton = {
-  send: (elm: HTMLElement) => {
-    const parentElement = elm.parentElement
-    if (parentElement) {
-      const sendButton = parentElement.querySelector(
-        '[data-testid="send-button"]'
-      ) as HTMLButtonElement | null
-      return sendButton
-    }
-    return undefined
-  },
+  send: (elm: HTMLElement) =>
+    elm.parentElement?.querySelector('[data-testid="send-button"]') as
+      | HTMLButtonElement
+      | undefined,
   edit: (elm: HTMLElement) =>
     elm.nextElementSibling?.getElementsByTagName('button')[0]
 }

--- a/src/contents/chatgpt.ts
+++ b/src/contents/chatgpt.ts
@@ -8,8 +8,16 @@ export const config: PlasmoCSConfig = {
 }
 
 const sendButton = {
-  send: (elm: HTMLElement) =>
-    elm.nextElementSibling as HTMLButtonElement | undefined,
+  send: (elm: HTMLElement) => {
+    let sibling: HTMLElement | null = elm
+    while (sibling !== null) {
+      sibling = sibling.nextElementSibling as HTMLElement | null
+      if (sibling && sibling.getAttribute('data-testid') === 'send-button') {
+        return sibling as HTMLButtonElement
+      }
+    }
+    return undefined
+  },
   edit: (elm: HTMLElement) =>
     elm.nextElementSibling?.getElementsByTagName('button')[0]
 }


### PR DESCRIPTION
## 内容

chatgptのdomが変化し、特定のタブでctrl-enterが機能していなかった問題を解決

## 変更点

sendボタンの指定方法を、兄弟要素を走査してdata-testid="send-buttonをもつ要素を指定するようにした
