### PR TITLE
fix:chatgptのマッチするurlを追加

### DIFF
--- a/src/contents/chatgpt.ts
+++ b/src/contents/chatgpt.ts
@@ -3,7 +3,7 @@ import { getConfig } from 'src/utils/config'
 import { key } from 'src/utils/key'
 
 export const config: PlasmoCSConfig = {
-  matches: ['https://chat.openai.com/*'],
+  matches: ['https://chat.openai.com/*', 'https://chatgpt.com/*'],
   all_frames: true
 }
 


### PR DESCRIPTION
## 内容

chatgptのサイトのurlが変更されたことに対応

## 変更点

chatgpt.tsのマッチするurlに"https://chatgpt.com/*"を追加

## 関連 Issue

close #61 
