### PR TITLE
fix:ChatGPTのDOM変化に対応

### DIFF
--- a/src/contents/ChatgptUi.tsx
+++ b/src/contents/ChatgptUi.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { getConfig, getSetting } from 'src/utils/config'
 
 export const config: PlasmoCSConfig = {
-  matches: ['https://chat.openai.com/*'],
+  matches: ['https://chat.openai.com/*', 'https://chatgpt.com/*'],
 }
 
 export const getInlineAnchor: PlasmoGetInlineAnchor = async () => {

--- a/src/contents/ChatgptUi.tsx
+++ b/src/contents/ChatgptUi.tsx
@@ -8,10 +8,9 @@ export const config: PlasmoCSConfig = {
 }
 
 export const getInlineAnchor: PlasmoGetInlineAnchor = async () => {
-  const textbox = document.querySelector<HTMLElement>(
-    'div:has(> div > #prompt-textarea)',
-  ) as Element
-  return textbox
+  const textbox = document.querySelector<HTMLElement>('textarea') as Element
+  const parents = textbox.closest("[class^='flex w-full items-center']")
+  return parents as Element
 }
 
 export const getShadowHostId = () => 'ctrl-enter-chatgpt'
@@ -53,9 +52,7 @@ const PlasmoInline = () => {
   })
   return (
     <div style={{ width: '100%' }}>
-      {config !== undefined && setting && (
-        <p style={styles}>{`${config ? 'Ctrl + ' : ''}Enter で送信`}</p>
-      )}
+      {config !== undefined && config && setting && <p style={styles}>{'Ctrl + Enter で送信'}</p>}
       <div />
     </div>
   )

--- a/src/contents/chatgpt.ts
+++ b/src/contents/chatgpt.ts
@@ -10,9 +10,7 @@ export const config: PlasmoCSConfig = {
 
 const sendButton = {
   send: (elm: HTMLElement) =>
-    elm.parentElement?.querySelector('[data-testid="send-button"]') as
-      | HTMLButtonElement
-      | undefined,
+    elm.parentElement?.nextElementSibling as HTMLButtonElement | undefined,
   edit: (elm: HTMLElement) => elm.nextElementSibling?.getElementsByTagName('button')[0],
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,7 +6,7 @@ export const supportSites = {
   discord: ['https://discord.com'],
   twitter: ['https://twitter.com', 'https://mobile.twitter.com', 'https://x.com'],
   instagram: ['https://www.instagram.com', 'https://instagram.com'],
-  chatgpt: ['https://chat.openai.com'],
+  chatgpt: ['https://chat.openai.com', 'https://chatgpt.com'],
   bing: ['https://www.bing.com'],
   bard: ['https://bard.google.com'],
   meet: ['https://meet.google.com/*'],


### PR DESCRIPTION
## 内容

chatgptのマッチするurlの修正漏れを修正
chatgptのDOM構造変化によって機能しなくなっていたものを修正
入力方法の表示を修正(chatgptサイトはもとがEnter送信ではないため)

## スクリーンショット・動画など

![Screenshot 2024-05-15 200302](https://github.com/mst-mkt/ctrl-enter/assets/131662745/09af418a-9b7c-46fe-a4f0-a3d211e8ca86)
